### PR TITLE
More future-proof declaration of development requirements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# Use shell.nix to build the development environment
+use nix

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 1. To set-up the environment for you'll need:
 
 - [Ruby](https://www.ruby-lang.org/en/downloads/) (2.4 or above)
+- [Python 2](https://www.python.org/downloads/)
 - [Jekyll](https://jekyllrb.com/)
-- [NodeJS](https://nodejs.org/en/) (0.12 or greater)
+- [NodeJS](https://nodejs.org/en/) (0.10)
 - [Git](https://git-scm.com/)
 
+Alternatively, if you have [`nix`](https://nixos.org/nix/) installed, a simple run of `nix-shell` is enough to build & install all of the above.
 
 2. After installation clone this repository and install dependencies :
 ```npm install```
@@ -31,7 +33,7 @@ If you want to deploy to your forked repo's Github page (resides in a subfolder)
 ```- bundle exec jekyll build --config _config_gh_pages.yml```
 
 After you're ready to push to production, change the line back to default one:
-```- bundle exec jekyll build```
+```bundle exec jekyll build```
 
 4. Build assets
 We use gulp to build the assets (SCSS to css, copy vendor files).

--- a/_config_local.yml
+++ b/_config_local.yml
@@ -16,6 +16,3 @@ defaults:
       path: "assets/img"
     values:
       image: true
-
-plugins:
-  - jekyll-feed

--- a/jekyll-sassc-patch.nix
+++ b/jekyll-sassc-patch.nix
@@ -1,0 +1,30 @@
+self: super:
+let
+  # See https://github.com/NixOS/nixpkgs/issues/19098
+  # and https://github.com/sass/sassc-ruby/pull/166
+  patch = builtins.toFile "lto.patch" ''
+    diff --git a/ext/extconf.rb b/ext/extconf.rb
+    index 08e067c..754988d 100644
+    --- a/ext/extconf.rb
+    +++ b/ext/extconf.rb
+    @@ -25,7 +25,7 @@ if enable_config('march-tune-native', true)
+       $CXXFLAGS << ' -march=native -mtune=native'
+     end
+
+    -if enable_config('lto', true)
+    +if enable_config('lto', false)
+       $CFLAGS << ' -flto'
+       $CXXFLAGS << ' -flto'
+       $LDFLAGS << ' -flto'
+  '';
+in {
+  jekyll = super.jekyll.override (old: {
+    bundlerApp = attrs: old.bundlerApp (attrs // {
+      gemset = let
+        gems = import (attrs.gemdir + "/gemset.nix");
+      in super.lib.recursiveUpdate gems {
+        sassc.patches = super.lib.optional self.stdenv.isDarwin [ patch ];
+      };
+    });
+  });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+let
+  nixpkgs = builtins.fetchTarball {
+    # https://github.com/NixOS/nixpkgs/tree/nixos-19.09 on 2020-01-12
+    url = "https://github.com/nixos/nixpkgs/archive/f7d050ed4e3af90502c88bf0ae1fef62dcbde265.tar.gz";
+    sha256 = "0fqs1z9q4zz938n6i32vh2sqrkk9yp15bk6kxpy8yrh3bxi2vqz9";
+  };
+  pkgs = import nixpkgs { config = { allowUnfree = true; }; };
+in
+
+pkgs.mkShell {
+  name = "dev-shell";
+  buildInputs = with pkgs; [
+    gitMinimal
+    nodejs-10_x
+    nodePackages.gulp
+    jekyll
+    python27Full
+  ]
+
+  # Some npm dependencies have a few extra requirements on Darwin (MacOS)
+  ++ lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.darwin.apple_sdk.frameworks.CoreServices
+  ]
+  ;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,12 @@ let
     url = "https://github.com/nixos/nixpkgs/archive/f7d050ed4e3af90502c88bf0ae1fef62dcbde265.tar.gz";
     sha256 = "0fqs1z9q4zz938n6i32vh2sqrkk9yp15bk6kxpy8yrh3bxi2vqz9";
   };
-  pkgs = import nixpkgs { config = { allowUnfree = true; }; };
+  pkgs = import nixpkgs {
+    config = { allowUnfree = true; };
+    overlays = [
+      (import ./jekyll-sassc-patch.nix)
+    ];
+  };
 in
 
 pkgs.mkShell {


### PR DESCRIPTION
Declare dev dependencies in a `shell.nix` file for those that want it.

I first went the usual route, using Homebrew and the likes to get the dev env setup. After two hours of frustrating juggling of correct binaries and their versions I realized I probably won't be the only one having these issues. So I rather spent my time on creating a `shell.nix` that anyone, on any OS, can use to install everything needed for commands in `README.md` to work.