### PR TITLE
shell.nix: Override to fix jekyll on macOS

### DIFF
--- a/jekyll-sassc-patch.nix
+++ b/jekyll-sassc-patch.nix
@@ -1,0 +1,30 @@
+self: super:
+let
+  # See https://github.com/NixOS/nixpkgs/issues/19098
+  # and https://github.com/sass/sassc-ruby/pull/166
+  patch = builtins.toFile "lto.patch" ''
+    diff --git a/ext/extconf.rb b/ext/extconf.rb
+    index 08e067c..754988d 100644
+    --- a/ext/extconf.rb
+    +++ b/ext/extconf.rb
+    @@ -25,7 +25,7 @@ if enable_config('march-tune-native', true)
+       $CXXFLAGS << ' -march=native -mtune=native'
+     end
+
+    -if enable_config('lto', true)
+    +if enable_config('lto', false)
+       $CFLAGS << ' -flto'
+       $CXXFLAGS << ' -flto'
+       $LDFLAGS << ' -flto'
+  '';
+in {
+  jekyll = super.jekyll.override (old: {
+    bundlerApp = attrs: old.bundlerApp (attrs // {
+      gemset = let
+        gems = import (attrs.gemdir + "/gemset.nix");
+      in super.lib.recursiveUpdate gems {
+        sassc.patches = super.lib.optional self.stdenv.isDarwin [ patch ];
+      };
+    });
+  });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,12 @@ let
     url = "https://github.com/nixos/nixpkgs/archive/f7d050ed4e3af90502c88bf0ae1fef62dcbde265.tar.gz";
     sha256 = "0fqs1z9q4zz938n6i32vh2sqrkk9yp15bk6kxpy8yrh3bxi2vqz9";
   };
-  pkgs = import nixpkgs { config = { allowUnfree = true; }; };
+  pkgs = import nixpkgs {
+    config = { allowUnfree = true; };
+    overlays = [
+      (import ./jekyll-sassc-patch.nix)
+    ];
+  };
 in
 
 pkgs.mkShell {


### PR DESCRIPTION
This fixes an error in the nix version of jekyll on darwin when running `jekyll serve --config _config_local.yml`. The error was:
```
/nix/store/hk9w40f7y8qpi413yjfkh3p98kcp5jli-ruby2.6.5-ffi-1.11.2/lib/ruby/gems/2.6.0/gems/ffi-1.11.2/lib/ffi/library.rb:273:in `attach_function': 
  Function 'libsass_version' not found in [/nix/store/ci77rd3c79y5hyjba66rymhmg7irjl8b-ruby2.6.5-sassc-2.2.1/lib/ruby/gems/2.6.0/gems/sassc-2.2.1/lib/sassc/libsass.bundle] (FFI::NotFoundError)
```

Related tickets are
- https://github.com/NixOS/nixpkgs/issues/19098 the actual issue, which seems hard to fix (an attempt is in https://github.com/NixOS/nixpkgs/pull/19312)
- https://github.com/sass/sassc-ruby/pull/166 which would obviate the need for this patch here, but just a workaround (see also https://github.com/sass/sassc-ruby/issues/148)

Applying a patch to a gem gets very annoying since nixpkgs's Ruby infrastructure doesn't seem to be made for easy overrides of this.

This PR is based on the branch of https://github.com/DragonPyConf/dragonpy.com/pull/11 (ping @zupo)