### PR TITLE
Add cache-busting based on build time

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,5 +12,5 @@
     <link rel="mask-icon" href="{{ '/safari-pinned-tab.svg' | absolute_url }}" color="#5bbad5">
     <link href="https://fonts.googleapis.com/css?family=Lato:400,400i,700,900&display=swap&subset=latin-ext"
           rel="stylesheet">
-    <link rel="stylesheet" href="{{ 'assets/css/app.css' | absolute_url }}">
+    <link rel="stylesheet" href="{{ 'assets/css/app.css' | absolute_url }}?v={{ site.time | date:'%s' }}"">
 </head>


### PR DESCRIPTION
Each time the site is deployed it will get a new string appended to the CSS URL.

ref: https://github.com/DragonPyConf/dragonpy.com/issues/18